### PR TITLE
Fix: Resolve login blinking issue by improving auth state handling

### DIFF
--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -155,16 +155,24 @@ const Login: React.FC = () => {
 
   // Redirect if already logged in
   useEffect(() => {
-    if (user) {
-      toast({
-        title: "Already logged in",
-        description: "Redirecting to your dashboard...",
-      });
-      
-      const dashboardPath = user.role === "doctor" ? "/doctor" : "/patient";
-      navigate(dashboardPath);
+    // Only redirect if auth is not loading and user is confirmed
+    if (user && !authLoading) {
+      // Ensure user.role is available before navigating
+      if (user.role) {
+        toast({
+          title: "Already logged in",
+          description: "Redirecting to your dashboard...",
+        });
+
+        const dashboardPath = user.role === "doctor" ? "/doctor" : "/patient";
+        navigate(dashboardPath);
+      } else {
+        // This case might happen if user is set but role is not yet populated
+        // (e.g. preliminary user object). Avoid redirecting.
+        console.log("Login page: User object exists but role is not yet defined. Waiting for role.");
+      }
     }
-  }, [user, navigate, toast]);
+  }, [user, authLoading, navigate, toast]);
 
   const handleRoleSelect = (role: 'patient' | 'doctor') => {
     setSelectedRole(role);


### PR DESCRIPTION
Introduced an `explicitLoginInProgress` state in AuthContext to ensure `isLoading` is managed correctly throughout the explicit login process,\preventing premature state changes by `onAuthStateChange`.

Updated Login.tsx to only redirect when `authLoading` is false and the user object includes the `role`, preventing redirects based on intermediate or incomplete user states.

These changes prevent rapid refreshes or blinking during login by ensuring UI updates and navigations occur only after the authentication and profile validation process is fully resolved.